### PR TITLE
Update styled-components version to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   "homepage": "https://github.com/maxkudla/styled-components-rtl#readme",
   "dependencies": {
     "cssjanus": "^1.3.2",
-    "styled-components": "^5.0.1"
+    "styled-components": "^5.2.0"
   }
 }


### PR DESCRIPTION
I wanted to update the `cssjanus` package also, but it's a major version and requires node version 10 or later.
@maxkudla would you like to do the same (only support for node >10)? I think it's worth it.